### PR TITLE
카테고리 검색 페이징 처리

### DIFF
--- a/src/main/java/com/nhnacademy/book_server/controller/CategoryController.java
+++ b/src/main/java/com/nhnacademy/book_server/controller/CategoryController.java
@@ -4,9 +4,13 @@ import com.nhnacademy.book_server.controller.swagger.CategorySwagger;
 import com.nhnacademy.book_server.dto.BookResponse;
 import com.nhnacademy.book_server.dto.CategoryResponse;
 import com.nhnacademy.book_server.entity.Category;
+import com.nhnacademy.book_server.service.BookService;
 import com.nhnacademy.book_server.service.category.CategoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,8 +44,8 @@ public class CategoryController implements CategorySwagger {
 
     @Override
     @GetMapping("/{categoryId}/books")
-    public ResponseEntity<List<BookResponse>> getBooksByCategory(@PathVariable("categoryId") int categoryId) {
-        return ResponseEntity.ok(categoryService.getBooksByCategory(categoryId));
-
+    public ResponseEntity<Page<BookResponse>> getBooksByCategory(@PathVariable("categoryId") int categoryId,
+                                                                 @PageableDefault(size = 12) Pageable pageable) {
+        return ResponseEntity.ok(categoryService.getBooksByCategory(categoryId, pageable));
     }
 }

--- a/src/main/java/com/nhnacademy/book_server/controller/swagger/CategorySwagger.java
+++ b/src/main/java/com/nhnacademy/book_server/controller/swagger/CategorySwagger.java
@@ -63,5 +63,6 @@ public interface CategorySwagger {
 
     ResponseEntity<Page<BookResponse>> getBooksByCategory(
             @Parameter(description = "카테고리 ID", example = "10")
-            @PathVariable int categoryId, Pageable pageable);
+            @PathVariable int categoryId,
+            @Parameter(hidden = true) Pageable pageable);
 }

--- a/src/main/java/com/nhnacademy/book_server/controller/swagger/CategorySwagger.java
+++ b/src/main/java/com/nhnacademy/book_server/controller/swagger/CategorySwagger.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -59,7 +61,7 @@ public interface CategorySwagger {
             @ApiResponse(responseCode = "404", description = "카테고리 없음")
     })
 
-    ResponseEntity<List<BookResponse>> getBooksByCategory(
+    ResponseEntity<Page<BookResponse>> getBooksByCategory(
             @Parameter(description = "카테고리 ID", example = "10")
-            @PathVariable int categoryId);
+            @PathVariable int categoryId, Pageable pageable);
 }

--- a/src/main/java/com/nhnacademy/book_server/repository/BookRepository.java
+++ b/src/main/java/com/nhnacademy/book_server/repository/BookRepository.java
@@ -51,13 +51,12 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     List<Book> findByIdIn(List<Long> ids); //카테고리-> 북리스트 후 정렬
 
 
-    @Query("SELECT bc FROM BookCategory bc " +
+    @Query(value = "SELECT bc FROM BookCategory bc " +
             "JOIN FETCH bc.book b " +
-            "LEFT JOIN FETCH b.publisher p " + // 출판사 추가
-            "LEFT JOIN FETCH b.bookAuthors ba " +
-            "LEFT JOIN FETCH ba.author " +
-            "WHERE bc.category.categoryId = :categoryId")
-        Page<BookCategory> findBooksByCategoryWithAuthors(@Param("categoryId") int categoryId, Pageable pageable);
+            "LEFT JOIN FETCH b.publisher p " +
+            "WHERE bc.category.categoryId = :categoryId",
+            countQuery = "SELECT count(bc) FROM BookCategory bc WHERE bc.category.categoryId = :categoryId")
+        Page<BookCategory> findBooksByCategory(@Param("categoryId") int categoryId, Pageable pageable);
 
 
 //    @Query("SELECT b FROM Book b WHERE b.bookCategories IS EMPTY")

--- a/src/main/java/com/nhnacademy/book_server/repository/BookRepository.java
+++ b/src/main/java/com/nhnacademy/book_server/repository/BookRepository.java
@@ -57,7 +57,7 @@ public interface BookRepository extends JpaRepository<Book, Long> {
             "LEFT JOIN FETCH b.bookAuthors ba " +
             "LEFT JOIN FETCH ba.author " +
             "WHERE bc.category.categoryId = :categoryId")
-        List<BookCategory> findBooksByCategoryWithAuthors(@Param("categoryId") int categoryId);
+        Page<BookCategory> findBooksByCategoryWithAuthors(@Param("categoryId") int categoryId, Pageable pageable);
 
 
 //    @Query("SELECT b FROM Book b WHERE b.bookCategories IS EMPTY")

--- a/src/main/java/com/nhnacademy/book_server/service/BookService.java
+++ b/src/main/java/com/nhnacademy/book_server/service/BookService.java
@@ -438,7 +438,7 @@ public class BookService {
 
     @Transactional(readOnly = true)
     public Page<BookResponse> getBooksByCategory(int categoryId, Pageable pageable) {
-        Page<BookCategory> books = bookRepository.findBooksByCategoryWithAuthors(categoryId, pageable);
+        Page<BookCategory> books = bookRepository.findBooksByCategory(categoryId, pageable);
         return books.map(bc -> BookResponse.from(bc.getBook()));
     }
 

--- a/src/main/java/com/nhnacademy/book_server/service/BookService.java
+++ b/src/main/java/com/nhnacademy/book_server/service/BookService.java
@@ -437,11 +437,9 @@ public class BookService {
     }
 
     @Transactional(readOnly = true)
-    public List<BookResponse> getBooksByCategory(int categoryId) {
-        List<BookCategory> books = bookRepository.findBooksByCategoryWithAuthors(categoryId);
-        return books.stream()
-                .map(bc -> BookResponse.from(bc.getBook()))
-                .toList();
+    public Page<BookResponse> getBooksByCategory(int categoryId, Pageable pageable) {
+        Page<BookCategory> books = bookRepository.findBooksByCategoryWithAuthors(categoryId, pageable);
+        return books.map(bc -> BookResponse.from(bc.getBook()));
     }
 
     // BookService나 도서 등록 로직 내부

--- a/src/main/java/com/nhnacademy/book_server/service/category/CategoryService.java
+++ b/src/main/java/com/nhnacademy/book_server/service/category/CategoryService.java
@@ -6,6 +6,8 @@ import com.nhnacademy.book_server.entity.Category;
 import com.nhnacademy.book_server.repository.CategoryRepository;
 import com.nhnacademy.book_server.service.BookService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,11 +45,11 @@ public class CategoryService {
 
     // 카테고리별 도서 조회
     @Transactional(readOnly = true)
-    public List<BookResponse> getBooksByCategory(int categoryId) {
+    public Page<BookResponse> getBooksByCategory(int categoryId, Pageable pageable) {
         // category 존재 검증만 수행
         categoryRepository.findByCategoryId(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("category not found: " + categoryId));
 
-        return bookService.getBooksByCategory(categoryId);
+        return bookService.getBooksByCategory(categoryId, pageable);
     }
 }

--- a/src/test/java/com/nhnacademy/book_server/controller/category/CategoryControllerTest.java
+++ b/src/test/java/com/nhnacademy/book_server/controller/category/CategoryControllerTest.java
@@ -10,16 +10,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -35,7 +36,7 @@ class CategoryControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private CategoryService categoryService;
 
     @Autowired
@@ -126,14 +127,14 @@ class CategoryControllerTest {
                 null
         );
 
-        given(categoryService.getBooksByCategory(categoryId))
-                .willReturn(List.of(bookResponse));
+        given(categoryService.getBooksByCategory(eq(categoryId), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(bookResponse)));
 
         // when & then
         mockMvc.perform(get("/api/categories/{categoryId}/books", categoryId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(1))
-                .andExpect(jsonPath("$[0].title").value("테스트 도서"));
+                .andExpect(jsonPath("$.content.size()").value(1))
+                .andExpect(jsonPath("$.content[0].title").value("테스트 도서"));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 카테고리 검색 페이징 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 카테고리별 도서 목록 조회 API에 페이지네이션 지원 추가
  * 기본 페이지 크기는 12개 항목으로 설정되어 대량 데이터의 효율적인 로드 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->